### PR TITLE
Update Info.plist to add support for Ricoh R5U2xx (R5U230 / RU231 / R5U241)

### DIFF
--- a/JMicron-Card-Reader/Payload/JMB38X.kext/Contents/Info.plist
+++ b/JMicron-Card-Reader/Payload/JMB38X.kext/Contents/Info.plist
@@ -27,7 +27,7 @@
 			<key>IOClass</key>
 			<string>JMB38X</string>
 			<key>IOPCIMatch</key>
-			<string>0x2392197B</string>
+			<string>0x2392197B 0xE8221180</string>
 			<key>IOProviderClass</key>
 			<string>IOPCIDevice</string>
 		</dict>


### PR DESCRIPTION
Add support for Ricoh R5U2xx (R5U230 / RU231 / R5U241). Tested and fully functioning on Alienware M17x R2 laptop.